### PR TITLE
Update pyenv to the newest version

### DIFF
--- a/puphpet/puppet/modules/pyenv/manifests/init.pp
+++ b/puphpet/puppet/modules/pyenv/manifests/init.pp
@@ -1,7 +1,7 @@
 class pyenv(
   $ensure_repo           = 'present',
   $repo_location         = '/usr/local/pyenv',
-  $repo_revision         = 'v0.4.0-20140404',
+  $repo_revision         = 'v20160509',
   $symlink_pyenv         = true,
   $symlink_path          = '/usr/local/bin',
   $manage_packages       = true,


### PR DESCRIPTION
Pyenv version haven't changed for a while. There are new commands like `pyenv install`, in contrast to what's available on 2014.04.04 version.
